### PR TITLE
Patchset 1

### DIFF
--- a/src/Makefile.mingw
+++ b/src/Makefile.mingw
@@ -8,7 +8,7 @@ OBJ = 386.o 386_dynarec.o 386_dynarec_ops.o 808x.o acer386sx.o acerm3a.o ali1429
 	cdrom-null.o codegen.o codegen_ops.o codegen_timing_486.o codegen_timing_686.o codegen_timing_pentium.o codegen_timing_winchip.o codegen_x86.o compaq.o config.o cpu.o dac.o \
 	device.o disc.o disc_86f.o disc_fdi.o disc_imd.o disc_img_86box.o disc_random.o disc_td0.o dma.o fdc.o fdc37c665.o fdc37c932fr.o fdd.o fdi2raw.o gameport.o headland.o i430hx.o i430lx.o i430fx.o \
 	i430nx.o i430vx.o i440fx.o ide.o intel.o intel_flash.o io.o jim.o joystick_ch_flightstick_pro.o joystick_standard.o joystick_sw_pad.o joystick_tm_fcs.o keyboard.o keyboard_amstrad.o keyboard_at.o \
-	keyboard_olim24.o keyboard_pcjr.o keyboard_xt.o lpt.o mcr.o mem.o memregs.o model.o mouse.o mouse_ps2.o \
+	keyboard_olim24.o keyboard_pcjr.o keyboard_xt.o lpt.o mcr.o mem.o memregs.o model.o mouse.o mouse_amstrad.o mouse_ps2.o \
 	mouse_serial.o ne2000.o neat.o nethandler.o nmi.o nvr.o olivetti_m24.o opti.o pc.o pc87306.o pci.o pic.o piix.o pit.o ppi.o ps1.o rom.o rtc.o \
 	scat.o serial.o sis496.o sis85c471.o sio.o sound.o sound_ad1848.o sound_adlib.o sound_adlibgold.o sound_cms.o \
 	sound_dbopl.o sound_emu8k.o sound_gus.o sound_mpu401_uart.o sound_opl.o sound_pas16.o sound_ps1.o sound_pssj.o sound_resid.o \

--- a/src/Makefile.mingw64
+++ b/src/Makefile.mingw64
@@ -8,7 +8,7 @@ OBJ = 386.o 386_dynarec.o 386_dynarec_ops.o 808x.o acer386sx.o acerm3a.o ali1429
 	cdrom-null.o codegen.o codegen_ops.o codegen_timing_486.o codegen_timing_686.o codegen_timing_pentium.o codegen_timing_winchip.o codegen_x86-64.o compaq.o config.o cpu.o dac.o \
 	device.o disc.o disc_86f.o disc_fdi.o disc_imd.o disc_img_86box.o disc_random.o disc_td0.o dma.o fdc.o fdc37c665.o fdc37c932fr.o fdd.o fdi2raw.o gameport.o headland.o i430hx.o i430lx.o i430fx.o \
 	i430nx.o i430vx.o i440fx.o ide.o intel.o intel_flash.o io.o jim.o joystick_ch_flightstick_pro.o joystick_standard.o joystick_sw_pad.o joystick_tm_fcs.o keyboard.o keyboard_amstrad.o keyboard_at.o \
-	keyboard_olim24.o keyboard_pcjr.o keyboard_xt.o lpt.o mcr.o mem.o memregs.o model.o mouse.o mouse_ps2.o \
+	keyboard_olim24.o keyboard_pcjr.o keyboard_xt.o lpt.o mcr.o mem.o memregs.o model.o mouse.o mouse_amstrad.o mouse_ps2.o \
 	mouse_serial.o ne2000.o neat.o nethandler.o nmi.o nvr.o olivetti_m24.o opti.o pc.o pc87306.o pci.o pic.o piix.o pit.o ppi.o ps1.o rom.o rtc.o \
 	scat.o serial.o sis496.o sis85c471.o sio.o sound.o sound_ad1848.o sound_adlib.o sound_adlibgold.o sound_cms.o \
 	sound_dbopl.o sound_emu8k.o sound_gus.o sound_mpu401_uart.o sound_opl.o sound_pas16.o sound_ps1.o sound_pssj.o sound_resid.o \

--- a/src/model.c
+++ b/src/model.c
@@ -276,6 +276,7 @@ void ams_init()
 	mem_add_bios();
         amstrad_init();
         keyboard_amstrad_init();
+		mouse_serial_init();
         nvr_init();
         xtide_init();
 	nmi_init();
@@ -300,6 +301,7 @@ void olim24_init()
         common_init();
 	mem_add_bios();
         keyboard_olim24_init();
+		mouse_serial_init();
         nvr_init();
         olivetti_m24_init();
         xtide_init();

--- a/src/model.c
+++ b/src/model.c
@@ -37,6 +37,7 @@
 #include "keyboard_xt.h"
 #include "lpt.h"
 #include "memregs.h"
+#include "mouse_amstrad.h"
 #include "mouse_ps2.h"
 #include "mouse_serial.h"
 #include "neat.h"
@@ -276,7 +277,7 @@ void ams_init()
 	mem_add_bios();
         amstrad_init();
         keyboard_amstrad_init();
-		mouse_serial_init();
+		mouse_amstrad_init();
         nvr_init();
         xtide_init();
 	nmi_init();

--- a/src/mouse_amstrad.c
+++ b/src/mouse_amstrad.c
@@ -1,0 +1,63 @@
+/* Copyright holders: SA1988, Curt Coder
+   see COPYING for more details
+*/
+#include "ibm.h"
+#include "io.h"
+#include "mouse.h"
+#include "mouse_amstrad.h"
+
+static int amstrad_x = 0, amstrad_y = 0, amstrad_b = 0;
+
+uint8_t mouse_amstrad_read(uint16_t port, void *priv)
+{
+	switch (port)
+	{
+		case 0x78:
+		return amstrad_x;
+		
+		case 0x7a:
+		return amstrad_y;
+	}
+	return 0xff;
+}
+
+void mouse_amstrad_write(uint16_t port, uint8_t val, void *priv)
+{
+	switch (port)
+	{
+		case 0x78:
+		amstrad_x = 0;
+		break;
+		
+		case 0x7a:
+		amstrad_y = 0;
+		break;
+	}
+}
+
+void mouse_amstrad_poll(int x, int y, int b)
+{
+        if (!x && !y && b==amstrad_b) return;
+
+        amstrad_b=b;
+		if (x > amstrad_x)
+			amstrad_x+=3;
+		else
+			amstrad_x-=3;
+		
+		amstrad_x = x;
+		
+		if (y > amstrad_y)
+			amstrad_y+=3;
+		else
+			amstrad_y-=3;		
+		
+        amstrad_y = y;
+}
+
+void mouse_amstrad_init()
+{
+        mouse_poll = mouse_amstrad_poll;
+		io_sethandler(0x0078, 0x0001, mouse_amstrad_read, NULL, NULL, mouse_amstrad_write, NULL, NULL, NULL);
+		io_sethandler(0x007a, 0x0001, mouse_amstrad_read, NULL, NULL, mouse_amstrad_write, NULL, NULL, NULL);
+}

--- a/src/mouse_amstrad.h
+++ b/src/mouse_amstrad.h
@@ -1,0 +1,4 @@
+/* Copyright holders: SA1988
+   see COPYING for more details
+*/
+void mouse_amstrad_init();

--- a/src/ps1.c
+++ b/src/ps1.c
@@ -130,7 +130,7 @@ void ps1mb_init()
         io_sethandler(0x0324, 0x0001, ps1_read, NULL, NULL, ps1_write, NULL, NULL, NULL);
         
         rom_init(&ps1_high_rom,
-                                "roms/ibmps1es/f80000.bin",
+                                "roms/ibmps1es/f80000_shell.bin",
                                 0xf80000,
                                 0x80000,
                                 0x7ffff,
@@ -279,7 +279,7 @@ void ps1mb_m2121_init()
         io_sethandler(0x0190, 0x0001, ps1_m2121_read, NULL, NULL, ps1_m2121_write, NULL, NULL, NULL);
 
         rom_init(&ps1_high_rom,
-                                "roms/ibmps1_2121/fc0000.bin",
+                                "roms/ibmps1_2121/fc0000_shell.bin",
                                 0xfc0000,
                                 0x40000,
                                 0x3ffff,

--- a/src/vid_ati28800.c
+++ b/src/vid_ati28800.c
@@ -315,6 +315,8 @@ void ati28800_recalctimings(svga_t *svga)
 #ifndef RELEASE_BUILD
         pclog("ati28800_recalctimings\n");
 #endif
+		svga->interlace = (!svga->scrblank && (ati28800->regs[0x30] & 0x20));
+		
         if (!svga->scrblank && (ati28800->regs[0x30] & 0x20)) /*Extended 256 colour modes*/
         {
 #ifndef RELEASE_BUILD


### PR DESCRIPTION
Added Amstrad mouse emulation:
Made the Amstrad models prior to the MegaPC use the new Amstrad mouse implementation.
IBM PS/1 ROM DOS Shell now optional.
Interlace support added to the ATI 28800, should allow 800x600x8bpp in the XL24.