### PR TITLE
Update sound_sb.c

### DIFF
--- a/src/sound_sb.c
+++ b/src/sound_sb.c
@@ -1,4 +1,4 @@
-
+#include <stdlib.h>
 #include "ibm.h"
 #include "device.h"
 #include "sound_emu8k.h"
@@ -468,7 +468,7 @@ void *sb_pro_v2_init()
         sb_mixer_init(&sb->mixer);
         io_sethandler(addr+0, 0x0004, opl3_read,   NULL, NULL, opl3_write,   NULL, NULL, &sb->opl);
         io_sethandler(addr+8, 0x0002, opl3_read,   NULL, NULL, opl3_write,   NULL, NULL, &sb->opl);
-        io_sethandler(0x0388, 0x0002, opl3_read,   NULL, NULL, opl3_write,   NULL, NULL, &sb->opl);
+        io_sethandler(0x0388, 0x0004, opl3_read,   NULL, NULL, opl3_write,   NULL, NULL, &sb->opl);
         io_sethandler(addr+4, 0x0002, sb_pro_mixer_read, NULL, NULL, sb_pro_mixer_write, NULL, NULL, sb);
         sound_add_handler(sb_get_buffer_opl3, sb);
 
@@ -495,7 +495,7 @@ void *sb_16_init()
         sb_mixer_init(&sb->mixer);
         io_sethandler(0x0220, 0x0004, opl3_read,   NULL, NULL, opl3_write,   NULL, NULL, &sb->opl);
         io_sethandler(0x0228, 0x0002, opl3_read,   NULL, NULL, opl3_write,   NULL, NULL, &sb->opl);
-        io_sethandler(0x0388, 0x0002, opl3_read,   NULL, NULL, opl3_write,   NULL, NULL, &sb->opl);
+        io_sethandler(0x0388, 0x0004, opl3_read,   NULL, NULL, opl3_write,   NULL, NULL, &sb->opl);
         io_sethandler(0x0224, 0x0002, sb_16_mixer_read, NULL, NULL, sb_16_mixer_write, NULL, NULL, sb);
         sound_add_handler(sb_get_buffer_opl3, sb);
         mpu401_uart_init(&sb->mpu, device_get_config_int("addr401"));
@@ -538,7 +538,7 @@ void *sb_awe32_init()
         sb_mixer_init(&sb->mixer);
         io_sethandler(0x0220, 0x0004, opl3_read,   NULL, NULL, opl3_write,   NULL, NULL, &sb->opl);
         io_sethandler(0x0228, 0x0002, opl3_read,   NULL, NULL, opl3_write,   NULL, NULL, &sb->opl);
-        io_sethandler(0x0388, 0x0002, opl3_read,   NULL, NULL, opl3_write,   NULL, NULL, &sb->opl);
+        io_sethandler(0x0388, 0x0004, opl3_read,   NULL, NULL, opl3_write,   NULL, NULL, &sb->opl);
         io_sethandler(0x0224, 0x0002, sb_16_mixer_read, NULL, NULL, sb_16_mixer_write, NULL, NULL, sb);
         sound_add_handler(sb_get_buffer_emu8k, sb);
         mpu401_uart_init(&sb->mpu, device_get_config_int("addr401"));


### PR DESCRIPTION
I solved OPL3 problem on SB Pro V2, SB16, AWE32.
This was defined 388h-389h only, so plays like OPL2.
OPL3 will plays correctly if this defined 388h-38bh.