### PR TITLE
Added Compaq Portable, Portable II, and Portable III (both 286 and 38…

### DIFF
--- a/src/hdd.c
+++ b/src/hdd.c
@@ -66,7 +66,6 @@ void hdd_controller_init(char *internal_name)
                 }
                 c++;
         }
-        fatal("Could not find hdd_controller %s\n", internal_name);
 }
 
 

--- a/src/ibm.h
+++ b/src/ibm.h
@@ -391,7 +391,11 @@ enum
         ROM_ENDEAVOR,
         ROM_REVENGE,
         ROM_IBMPS1_2011,
-        ROM_DESKPRO_386,	
+        ROM_DESKPRO_386,
+		ROM_PORTABLE,
+		ROM_PORTABLEII,
+		ROM_PORTABLEIII,
+		ROM_PORTABLEIII386, //The original Compaq Portable III shipped with an Intel 80286 CPU, but later switched to a 386DX.
         ROM_IBMPS1_2121,
 
         ROM_AMI386DX_OPTI495,

--- a/src/mem.c
+++ b/src/mem.c
@@ -201,6 +201,40 @@ int loadbios()
                 fclose(f);
                 return 1;
                 
+                case ROM_PORTABLE:
+                f=romfopen("roms/portable/Compaq Portable Plus 100666-001 Rev C u47.bin","rb");
+                if (!f) break;
+                fread(rom+0xE000,8192,1,f);
+                fclose(f);
+                return 1;
+
+                case ROM_PORTABLEII:
+                f = romfopen("roms/portableii/62x0820.u27", "rb");
+                ff  =romfopen("roms/portableii/62x0821.u47", "rb");
+                if (!f || !ff) break;
+                for (c=0x0000;c<0x10000;c+=2)
+                {
+                        rom[c]=getc(f);
+                        rom[c+1]=getc(ff);
+                }
+                fclose(ff);
+                fclose(f);
+                return 1;
+				
+                case ROM_PORTABLEIII:
+				case ROM_PORTABLEIII386:
+                f = romfopen("roms/portableiii/62x0820.u27", "rb");
+                ff  =romfopen("roms/portableiii/62x0821.u47", "rb");
+                if (!f || !ff) break;
+                for (c=0x0000;c<0x10000;c+=2)
+                {
+                        rom[c]=getc(f);
+                        rom[c+1]=getc(ff);
+                }
+                fclose(ff);
+                fclose(f);
+                return 1;				
+				
                 case ROM_GENXT:
                 f=romfopen("roms/genxt/pcxt.rom","rb");
                 if (!f) break;
@@ -519,10 +553,6 @@ int loadbios()
                 fread(rom, 0x20000, 1, f);                
                 fclose(f);
 //#endif
-		if (enable_xtide)
-		{
-			mem_load_atide115_bios();
-		}
                 biosmask = 0x1ffff;
                 return 1;
  

--- a/src/model.c
+++ b/src/model.c
@@ -72,6 +72,7 @@
 #include "vid_tandy.h"
 #include "w83877f.h"
 #include "wd76c10.h"
+#include "xtide.h"
 
 void            xt_init();
 void          pcjr_init();
@@ -108,6 +109,7 @@ void     at_mb500n_init();
 #if 0
 void at_powermate_v_init();
 #endif
+void at_compaq_2000_init();
 void   at_p54tp4xe_init();
 void    at_acerm3a_init();
 void   at_acerv35n_init();
@@ -127,6 +129,7 @@ MODEL models[] =
 {
         {"IBM PC",			ROM_IBMPC,		"ibmpc",		{ "",      cpus_8088,        "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 0, 0,                                     64, 640,  64,          xt_init, NULL},
         {"IBM XT",			ROM_IBMXT,		"ibmxt",		{ "",      cpus_8088,        "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 0, 0,                                     64, 640,  64,          xt_init, NULL},
+        {"Compaq Portable",			ROM_PORTABLE,		"portable",		{ "",      cpus_8088,        "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 0, 0,                                     128, 640,  128,          xt_init, NULL},
         {"IBM PCjr",			ROM_IBMPCJR,		"ibmpcjr",		{ "",      cpus_pcjr,        "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 1, 0,                                    128, 640, 128,        pcjr_init, &pcjr_device},
         {"Generic XT clone",		ROM_GENXT,		"genxt",		{ "",      cpus_8088,        "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 0, 0,                                     64, 640,  64,          xt_init, NULL},
         {"AMI XT clone",		ROM_AMIXT,		"amixt",		{ "",      cpus_8088,        "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 0, 0,                                     64, 640,  64,          xt_init, NULL},
@@ -146,17 +149,20 @@ MODEL models[] =
         {"Amstrad PC2086",		ROM_PC2086,		"pc2086",		{ "",      cpus_8086,        "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 1, MODEL_AMSTRAD,                        640, 640,   0,         ams_init, NULL},
         {"Amstrad PC3086",		ROM_PC3086,		"pc3086",		{ "",      cpus_8086,        "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 1, MODEL_AMSTRAD,                        640, 640,   0,         ams_init, NULL},
         {"IBM AT",			ROM_IBMAT,		"ibmat",		{ "",      cpus_ibmat,       "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 0, MODEL_AT,                               1,  16,   1,          at_init, NULL},
+        {"Compaq Portable II",		ROM_PORTABLEII,		"portableii",		{ "",      cpus_286,         "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 0, MODEL_AT,               1,  15,   1,     at_init, NULL},
+        {"Compaq Portable III",		ROM_PORTABLEIII,		"portableiii",		{ "",      cpus_286,         "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 0, MODEL_AT,               1,  15,   1,     at_init, NULL},
         {"Commodore PC 30 III",		ROM_CMDPC30,		"cmdpc30",		{ "",      cpus_286,         "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 0, MODEL_AT | MODEL_HAS_IDE,               1,  16,   1,          at_init, NULL},
         {"AMI 286 clone",		ROM_AMI286,		"ami286",		{ "",      cpus_286,         "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 0, MODEL_AT | MODEL_HAS_IDE,               1,  16,   1,     at_neat_init, NULL},        
         {"Award 286 clone",		ROM_AWARD286,		"award286",		{ "",      cpus_286,         "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 0, MODEL_AT | MODEL_HAS_IDE,               1,  16,   1,     at_scat_init, NULL},
         {"DELL System 200",		ROM_DELL200,		"dells200",		{ "",      cpus_286,         "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 0, MODEL_AT,                               1,  16,   1,          at_init, NULL},
         {"Hyundai Super-286TR",		ROM_SUPER286TR,		"super286tr",		{ "",      cpus_286,         "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 0, MODEL_AT,                               1,  16,   1,     at_scat_init, NULL},
         {"Samsung SPC-4200P",		ROM_SPC4200P,		"spc4200p",		{ "",      cpus_286,         "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 0, MODEL_AT,                               1,  16,   1,     at_scat_init, NULL},
-        {"IBM PS/1 model 2011",		ROM_IBMPS1_2011,	"ibmps1es",		{ "",      cpus_ps1_m2011,   "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 1, MODEL_AT | MODEL_PS2,                   1,  16,   1,   ps1_m2011_init, NULL},
-        {"IBM PS/2 Model 30-286",	ROM_IBMPS2_M30_286,	"ibmps2_m30_286",	{ "",      cpus_ps2_m30_286, "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 0, MODEL_AT | MODEL_PS2,                   1,  16,   1, ps2_m30_286_init, NULL},
+        {"IBM PS/1 model 2011",		ROM_IBMPS1_2011,	"ibmps1es",		{ "",      cpus_ps1_m2011,   "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 1, MODEL_AT | MODEL_PS2 | MODEL_PS2_HDD,                   1,  16,   1,   ps1_m2011_init, NULL},
+        {"IBM PS/2 Model 30-286",	ROM_IBMPS2_M30_286,	"ibmps2_m30_286",	{ "",      cpus_ps2_m30_286, "",    NULL,         "",      NULL,        "",      NULL,     "",      NULL}, 0, MODEL_AT | MODEL_PS2 | MODEL_PS2_HDD,                   1,  16,   1, ps2_m30_286_init, NULL},
         {"IBM PS/1 model 2121",		ROM_IBMPS1_2121,	"ibmps1_2121",		{ "Intel", cpus_i386SX,      "AMD", cpus_Am386SX, "Cyrix", cpus_486SLC, "",      NULL,     "",      NULL}, 1, MODEL_AT | MODEL_PS2 | MODEL_HAS_IDE,   1,  16,   1,   ps1_m2121_init, NULL},
         {"IBM PS/1 m.2121 + ISA",	ROM_IBMPS1_2121_ISA,	"ibmps1_2121_isa",	{ "Intel", cpus_i386DX,      "AMD", cpus_Am386DX, "Cyrix", cpus_486DLC, "",      NULL,     "",      NULL}, 0, MODEL_AT | MODEL_PS2 | MODEL_HAS_IDE,   1,  16,   1,   ps1_m2121_init, NULL},
         {"Compaq Deskpro 386",		ROM_DESKPRO_386,	"dekspro386",		{ "Intel", cpus_i386DX,      "AMD", cpus_Am386DX, "Cyrix", cpus_486DLC, "",      NULL,     "",      NULL}, 0, MODEL_AT,                               1,  15,   1,  deskpro386_init, NULL},
+        {"Compaq Portable III 386",		ROM_PORTABLEIII386,		"portableiii386",		{ "Intel", cpus_i386DX,      "AMD", cpus_Am386DX, "Cyrix", cpus_486DLC, "",      NULL,     "",      NULL}, 0, MODEL_AT,               1,  15,   1,     at_init, NULL},
         {"DTK 386SX clone",		ROM_DTK386,		"dtk386",		{ "Intel", cpus_i386SX,      "AMD", cpus_Am386SX, "Cyrix", cpus_486SLC, "",      NULL,     "",      NULL}, 0, MODEL_AT | MODEL_HAS_IDE,               1,  16,   1,     at_neat_init, NULL},
         {"Amstrad MegaPC",		ROM_MEGAPC,		"megapc",		{ "Intel", cpus_i386SX,      "AMD", cpus_Am386SX, "Cyrix", cpus_486SLC, "",      NULL,     "",      NULL}, 1, MODEL_AT | MODEL_PS2 | MODEL_HAS_IDE,   1,  16,   1,  at_wd76c10_init, NULL},
         {"AMI 386SX clone",		ROM_AMI386SX,		"ami386",		{ "Intel", cpus_i386SX,      "AMD", cpus_Am386SX, "Cyrix", cpus_486SLC, "",      NULL,     "",      NULL}, 0, MODEL_AT | MODEL_HAS_IDE,               1, 256,   1,  at_headland_init, NULL},
@@ -175,8 +181,8 @@ MODEL models[] =
         {"Intel Advanced/EV",		ROM_ENDEAVOR,		"endeavor",		{ "Intel", cpus_PentiumS5,   "IDT", cpus_WinChip, "AMD",   cpus_K5,     "",      NULL,     "",      NULL}, 0, MODEL_AT | MODEL_PS2 | MODEL_HAS_IDE,   1, 128,  1,  at_endeavor_init, NULL},
         {"Intel Advanced/ZP",		ROM_ZAPPA,		"zappa",		{ "Intel", cpus_PentiumS5,   "IDT", cpus_WinChip, "AMD",   cpus_K5,     "",      NULL,     "",      NULL}, 0, MODEL_AT | MODEL_PS2 | MODEL_HAS_IDE,   1, 128,  1,  at_endeavor_init, NULL},
         {"PC Partner MB500N",		ROM_MB500N,		"mb500n",		{ "Intel", cpus_PentiumS5,   "IDT", cpus_WinChip, "AMD",   cpus_K5,     "",      NULL,     "",      NULL}, 0, MODEL_AT | MODEL_PS2 | MODEL_HAS_IDE,   1, 128,  1,    at_mb500n_init, NULL},
-        {"Intel Advanced/ATX",		ROM_THOR,		"thor",			{ "Intel", cpus_Pentium,     "IDT", cpus_WinChip, "Cyrix", cpus_6x86,   "AMD",   cpus_K56, "",      NULL}, 0, MODEL_AT | MODEL_PS2 | MODEL_HAS_IDE,   1, 256,  1,  at_endeavor_init, NULL},
-        {"MR Intel Advanced/ATX",	ROM_MRTHOR,		"mrthor",		{ "Intel", cpus_Pentium,     "IDT", cpus_WinChip, "Cyrix", cpus_6x86,   "AMD",   cpus_K56, "",      NULL}, 0, MODEL_AT | MODEL_PS2 | MODEL_HAS_IDE,   1, 256,  1,  at_endeavor_init, NULL},
+        {"Intel Advanced/ATX",		ROM_THOR,		"thor",			{ "Intel", cpus_Pentium,     "IDT", cpus_WinChip, "Cyrix", cpus_6x86,   "AMD",   cpus_K56, "",      NULL}, 0, MODEL_AT | MODEL_PS2 | MODEL_HAS_IDE,   1, 512,  1,  at_endeavor_init, NULL},
+        {"MR Intel Advanced/ATX",	ROM_MRTHOR,		"mrthor",		{ "Intel", cpus_Pentium,     "IDT", cpus_WinChip, "Cyrix", cpus_6x86,   "AMD",   cpus_K56, "",      NULL}, 0, MODEL_AT | MODEL_PS2 | MODEL_HAS_IDE,   1, 512,  1,  at_endeavor_init, NULL},
         {"ASUS P/I-P54TP4XE",		ROM_P54TP4XE,		"p54tp4xe",		{ "Intel", cpus_PentiumS5,   "IDT", cpus_WinChip, "AMD",   cpus_K5,     "",      NULL,     "",      NULL}, 0, MODEL_AT | MODEL_PS2 | MODEL_HAS_IDE,   1, 512,  1,  at_p54tp4xe_init, NULL},
         {"Acer M3a",			ROM_ACERM3A,		"acerm3a",		{ "Intel", cpus_Pentium,     "IDT", cpus_WinChip, "Cyrix", cpus_6x86,   "AMD",   cpus_K56, "",      NULL}, 0, MODEL_AT | MODEL_PS2 | MODEL_HAS_IDE,   1, 512,  1,   at_acerm3a_init, NULL},
         {"Acer V35N",			ROM_ACERV35N,		"acerv3n",		{ "Intel", cpus_Pentium,     "IDT", cpus_WinChip, "Cyrix", cpus_6x86,   "AMD",   cpus_K56, "",      NULL}, 0, MODEL_AT | MODEL_PS2 | MODEL_HAS_IDE,   1, 512,  1,  at_acerv35n_init, NULL},
@@ -371,7 +377,10 @@ void ps1_common_init()
 	mem_add_bios();
         pit_set_out_func(1, pit_refresh_timer_at);
         dma16_init();
-        ide_init();
+        if (romset == ROM_IBMPS1_2011)
+			device_add(&xtide_ps2_device);
+		else
+			ide_init();
         keyboard_at_init();
         nvr_init();
         pic2_init();
@@ -401,7 +410,7 @@ void ps2_m30_286_init()
         mem_add_bios();
         pit_set_out_func(1, pit_refresh_timer_at);
         dma16_init();
-        ide_init();
+        device_add(&xtide_ps2_device);
         keyboard_at_init();
         nvr_init();
         pic2_init();

--- a/src/model.h
+++ b/src/model.h
@@ -9,6 +9,7 @@
 #define MODEL_NEC     32
 #define MODEL_FUJITSU 64
 #define MODEL_RM      128
+#define MODEL_PS2_HDD	  256
 
 typedef struct
 {

--- a/src/nvr.c
+++ b/src/nvr.c
@@ -211,6 +211,8 @@ void loadnvr()
                 case ROM_IBMPS1_2121_ISA: f = romfopen(nvr_concat("ibmps1_2121_isa.nvr"), "rb"); nvrmask = 127; break;
                 case ROM_IBMPS2_M30_286: f = romfopen(nvr_concat("ibmps2_m30_286.nvr"), "rb"); nvrmask = 127; break;
                 case ROM_CMDPC30:     f = romfopen(nvr_concat("cmdpc30.nvr"),     "rb"); nvrmask = 127; break;
+				case ROM_PORTABLEII:  f = romfopen(nvr_concat("portableii.nvr"),  "rb"); break;
+				case ROM_PORTABLEIII: f = romfopen(nvr_concat("portableiii.nvr"),  "rb"); break;
                 case ROM_AMI286:      f = romfopen(nvr_concat("ami286.nvr"),      "rb"); nvrmask = 127; break;
                 case ROM_AWARD286:    f = romfopen(nvr_concat("award286.nvr"),    "rb"); nvrmask = 127; break;
                 case ROM_DELL200:     f = romfopen(nvr_concat("dell200.nvr"),     "rb"); nvrmask = 127; break;
@@ -218,6 +220,7 @@ void loadnvr()
                 case ROM_SPC4200P:    f = romfopen(nvr_concat("spc4200p.nvr"),    "rb"); nvrmask = 127; break;
                 case ROM_IBMAT386:    f = romfopen(nvr_concat("at386.nvr"),       "rb"); nvrmask = 127; break;
                 case ROM_DESKPRO_386: f = romfopen(nvr_concat("deskpro386.nvr"),  "rb"); break;
+				case ROM_PORTABLEIII386: f = romfopen(nvr_concat("portableiii386.nvr"),  "rb"); break;
                 /* case ROM_ACER386:     f = romfopen(nvr_concat("acer386.nvr"),     "rb"); nvrmask = 127; break; */
                 case ROM_MEGAPC:      f = romfopen(nvr_concat("megapc.nvr"),      "rb"); nvrmask = 127; break;
                 case ROM_MEGAPCDX:    f = romfopen(nvr_concat("megapcdx.nvr"),    "rb"); nvrmask = 127; break;
@@ -298,7 +301,9 @@ void savenvr()
                 case ROM_IBMPS1_2121: f = romfopen(nvr_concat("ibmps1_2121.nvr"), "wb"); break;
                 case ROM_IBMPS1_2121_ISA: f = romfopen(nvr_concat("ibmps1_2121_isa.nvr"), "wb"); break;
                 case ROM_IBMPS2_M30_286: f = romfopen(nvr_concat("ibmps2_m30_286.nvr"), "wb"); break;
-                case ROM_CMDPC30:     f = romfopen(nvr_concat("cmdpc30.nvr"),     "wb"); break;                
+                case ROM_CMDPC30:     f = romfopen(nvr_concat("cmdpc30.nvr"),     "wb"); break;
+				case ROM_PORTABLEII: f = romfopen(nvr_concat("portableii.nvr"),  "wb"); break;
+				case ROM_PORTABLEIII: f = romfopen(nvr_concat("portableiii.nvr"),  "wb"); break;
                 case ROM_AMI286:      f = romfopen(nvr_concat("ami286.nvr"),      "wb"); break;
                 case ROM_AWARD286:    f = romfopen(nvr_concat("award286.nvr"),    "wb"); break;
                 case ROM_DELL200:     f = romfopen(nvr_concat("dell200.nvr"),     "wb"); break;
@@ -306,6 +311,7 @@ void savenvr()
                 case ROM_SPC4200P:    f = romfopen(nvr_concat("spc4200p.nvr"),    "wb"); break;
                 case ROM_IBMAT386:    f = romfopen(nvr_concat("at386.nvr"),       "wb"); break;
                 case ROM_DESKPRO_386: f = romfopen(nvr_concat("deskpro386.nvr"),  "wb"); break;
+				case ROM_PORTABLEIII386: f = romfopen(nvr_concat("portableiii386.nvr"),  "wb"); break;
                 /* case ROM_ACER386:     f = romfopen(nvr_concat("acer386.nvr"),     "wb"); break; */
                 case ROM_MEGAPC:      f = romfopen(nvr_concat("megapc.nvr"),      "wb"); break;
                 case ROM_MEGAPCDX:    f = romfopen(nvr_concat("megapcdx.nvr"),    "wb"); break;

--- a/src/win-config.c
+++ b/src/win-config.c
@@ -50,7 +50,14 @@ static void recalc_hdd_list(HWND hdlg, int model, int use_selected_hdd)
         
         h = GetDlgItem(hdlg, IDC_COMBOHDD);
         
-        if (models[model].flags & MODEL_HAS_IDE)
+		if (models[model].flags & MODEL_PS2_HDD)
+        {
+                SendMessage(h, CB_RESETCONTENT, 0, 0);
+                SendMessage(h, CB_ADDSTRING, 0, (LPARAM)(LPCSTR)"XTIDE for PS/2");
+                EnableWindow(h, FALSE);
+                SendMessage(h, CB_SETCURSEL, 0, 0);
+		}
+        else if (models[model].flags & MODEL_HAS_IDE)
         {
                 SendMessage(h, CB_RESETCONTENT, 0, 0);
                 SendMessage(h, CB_ADDSTRING, 0, (LPARAM)(LPCSTR)"Internal IDE");

--- a/src/xtide.c
+++ b/src/xtide.c
@@ -87,6 +87,17 @@ static void *xtide_at_init()
         return xtide;
 }
 
+static void *xtide_ps2_init()
+{
+        xtide_t *xtide = malloc(sizeof(xtide_t));
+        memset(xtide, 0, sizeof(xtide_t));
+
+        rom_init(&xtide->bios_rom, "roms/ide_at_1_1_5.bin", 0xc8000, 0x4000, 0x3fff, 0, MEM_MAPPING_EXTERNAL);
+        ide_init();
+        
+        return xtide;
+}
+
 static void xtide_close(void *p)
 {
         xtide_t *xtide = (xtide_t *)p;
@@ -102,6 +113,11 @@ static int xtide_available()
 static int xtide_at_available()
 {
         return rom_present("roms/ide_at.bin");
+}
+
+static int xtide_ps2_available()
+{
+        return rom_present("roms/ide_at_1_1_5.bin");
 }
 
 device_t xtide_device =
@@ -123,6 +139,19 @@ device_t xtide_at_device =
         xtide_at_init,
         xtide_close,
         xtide_at_available,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+};
+
+device_t xtide_ps2_device =
+{
+        "XTIDE (PS/2)",
+        DEVICE_AT,
+        xtide_ps2_init,
+        xtide_close,
+        xtide_ps2_available,
         NULL,
         NULL,
         NULL,

--- a/src/xtide.h
+++ b/src/xtide.h
@@ -1,2 +1,3 @@
 extern device_t xtide_device;
 extern device_t xtide_at_device;
+extern device_t xtide_ps2_device;


### PR DESCRIPTION
…6DX of the latter). Currently the original Portable has issues with CGA but works with the CGA-compatible Wyse 700 and EGA and higher).

IBM PS/1 2011 and PS/2 30-286 now default to XTIDE 1.1.5 when selected.