### PR TITLE
Implemented Sound Blaster MIDI through the DSP (was surprisingly miss…

### DIFF
--- a/src/SOUND/snd_mpu401.h
+++ b/src/SOUND/snd_mpu401.h
@@ -58,4 +58,6 @@ typedef struct mpu_t
 	} clock;
 } mpu_t;
 
+uint8_t MPU401_ReadData(mpu_t *mpu);
+
 void mpu401_init(mpu_t *mpu, uint16_t addr, int irq, int mode);

--- a/src/SOUND/snd_sb.c
+++ b/src/SOUND/snd_sb.c
@@ -781,6 +781,9 @@ static device_config_t sb_config[] =
                 }
         },
         {
+                "midi", "MIDI out device", CONFIG_MIDI, "", 0
+        },
+        {
                 "", "", -1
         }
 };
@@ -817,6 +820,9 @@ static device_config_t sb_mcv_config[] =
                                 ""
                         }
                 }
+        },
+        {
+                "midi", "MIDI out device", CONFIG_MIDI, "", 0
         },
         {
                 "", "", -1
@@ -872,6 +878,9 @@ static device_config_t sb_pro_config[] =
                                 ""
                         }
                 }
+        },
+        {
+                "midi", "MIDI out device", CONFIG_MIDI, "", 0
         },
         {
                 "", "", -1

--- a/src/SOUND/snd_sb_dsp.h
+++ b/src/SOUND/snd_sb_dsp.h
@@ -1,5 +1,9 @@
 typedef struct sb_dsp_t
-{
+{		
+		int uart_midi;
+		int uart_irq;
+		int onebyte_midi;
+		
         int sb_type;
 
         int sb_8_length,  sb_8_format,  sb_8_autoinit,  sb_8_pause,  sb_8_enable,  sb_8_autolen,  sb_8_output;


### PR DESCRIPTION
…ing before). Native Windows 3.1 and NT Sound Blaster drivers can now use their DSP to drive the MIDI out.

Added MIDI out config to pre-SB16's for this new change.