### PR TITLE
Clock of NT 3.1 now renders correctly with its S3 2.3 drivers.

### DIFF
--- a/src/sound/snd_mpu401.c
+++ b/src/sound/snd_mpu401.c
@@ -169,7 +169,6 @@ static void MPU401_WriteCommand(mpu_t *mpu, uint8_t val)
 	if (mpu->state.reset) 
 	{
 		mpu->state.cmd_pending=val+1;
-		return;
 	}
 	
 	if (val<=0x2f) 
@@ -678,9 +677,8 @@ static uint8_t mpu401_read(uint16_t addr, void *p)
 			break;
 			
 			case 1: //Read Status
-			ret = 0x3f; /* Bits 6 and 7 clear */
-			if (mpu->state.cmd_pending) ret|=STATUS_OUTPUT_NOT_READY;
-			if (!mpu->queue_used) ret|=STATUS_INPUT_NOT_READY;				
+			if (mpu->state.cmd_pending) ret=STATUS_OUTPUT_NOT_READY;
+			if (!mpu->queue_used) ret=STATUS_INPUT_NOT_READY;				
 			pclog("Read Status (0x331) %x\n", ret);
 			break;
 		}

--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -1696,6 +1696,8 @@ void s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                                 if (cpu_input/* && (s3->accel.multifunc[0xa] & 0xc0) == 0x80*/) return;
                                 if (s3->accel.sy < 0)
                                 {
+										s3->accel.cur_x = s3->accel.cx;
+										s3->accel.cur_y = s3->accel.cy;	
                                         return;
                                 }
                         }


### PR DESCRIPTION
Fix for the MPU-401 that was preventing certain SB16 drivers for Windows 3.1 and NT 3.1 to work properly.